### PR TITLE
Fix/read only configs

### DIFF
--- a/charts/zigbee2mqtt/Chart.yaml
+++ b/charts/zigbee2mqtt/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.37.1
+appVersion: 1.37.2
 description: Bridges events and allows you to control your Zigbee devices via MQTT
 name: zigbee2mqtt
-version: 1.37.1
+version: 1.37.2
 kubeVersion: ">=1.26.0-0"
 keywords:
   - zigbee

--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -37,6 +37,13 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}
+      initContainers:
+        - name: copy
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command: ["bash", "-c", "cp /config-map/configuration.yaml /app/data/"]
+          volumeMounts:
+            - mountPath: /config-map
+              name: config-map
       containers:
         - name: zigbee2mqtt
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -61,14 +68,11 @@ spec:
             timeoutSeconds: 10
             periodSeconds: 30
           volumeMounts:
-            - mountPath: /app/data/configuration.yaml
-              name: config-volume
-              subPath: configuration.yaml
             - mountPath: /app/data/
               name: data-volume
           resources: {{- toYaml .Values.statefulset.resources | nindent 12 }}
       volumes:
-        - name: config-volume
+        - name: config-map
           configMap:
             name: {{ include "zigbee2mqtt.fullname" . }}
         {{- if not .Values.statefulset.storage.enabled }}

--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -40,10 +40,12 @@ spec:
       initContainers:
         - name: copy
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          command: ["bash", "-c", "cp /config-map/configuration.yaml /app/data/"]
+          command: ["sh", "-c", "cp /config-map/configuration.yaml /app/data/"]
           volumeMounts:
             - mountPath: /config-map
               name: config-map
+            - mountPath: /app/data/
+              name: data-volume
       containers:
         - name: zigbee2mqtt
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Fixes issue where chart is using a configmap to house z2m's configuration.yaml contents. This results in an uneditable file which breaks the z2m application. z2m requires an editable configuration.yaml. 
The fix uses an initialization container to copy the contents of the configmap into a file in the mounted storage volume. 