### PR TITLE
Fix workflow OnZigbee2MQTTRelease

### DIFF
--- a/.github/workflows/on_zigbee2mqtt_release.yaml
+++ b/.github/workflows/on_zigbee2mqtt_release.yaml
@@ -1,6 +1,6 @@
 name: OnZigbee2MQTTRelease
 on:
-  repository_dispatch:
+  workflow_dispatch:
     inputs:
       zigbee2mqtt_version:
         description: 'Version of zigbee2mqtt released'


### PR DESCRIPTION
The workflow configuration was incorrect, so API could not trigger the workflow.