### PR TITLE
feat: trigger restart on configMap change

### DIFF
--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -13,6 +13,8 @@ spec:
       app: {{ include "zigbee2mqtt.fullname" . }}
   template:
     metadata:
+      annotations:
+        checksum/configuration: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "zigbee2mqtt.labels" . | nindent 8 }}
         app: {{ include "zigbee2mqtt.fullname" . }}


### PR DESCRIPTION
By attaching an annotation with the configMap's checksum to the Pod template, it will automatically be restarted when configuration changes are rolled out.