### PR TITLE
feat: make (pod)securityContext configurable

### DIFF
--- a/charts/zigbee2mqtt/README.md
+++ b/charts/zigbee2mqtt/README.md
@@ -43,8 +43,10 @@ Kubernetes: `>=1.26.0-0`
 | service.type | string | `"LoadBalancer"` | type of Service to be created |
 | statefulset.dnsPolicy | string | `"ClusterFirst"` | pod dns policy |
 | statefulset.nodeSelector | object | `{}` | Select specific kube node, this will allow enforcing zigbee2mqtt running only on the node with the USB adapter connected |
+| statefulset.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Configure Pods Security Context |
 | statefulset.resources | object | `{"limits":{"cpu":"200m","memory":"600Mi"},"requests":{"cpu":"200m","memory":"600Mi"}}` | CPU/Memory configuration for the pods |
 | statefulset.secrets.name | string | `""` | the name for the kubernets secret to mount as secret.yaml. This can be referenced in the config by using advanced configurations https://www.zigbee2mqtt.io/guide/configuration/frontend.html#advanced-configuration |
+| statefulset.securityContext | object | `{"capabilities":{"add":["SYS_ADMIN"]},"privileged":true}` | Configure Container Security Context |
 | statefulset.storage.enabled | bool | `false` |  |
 | statefulset.storage.existingVolume | string | `""` |  |
 | statefulset.storage.matchExpressions | object | `{}` |  |

--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -32,9 +32,10 @@ spec:
 {{- with .Values.statefulset.nodeSelector }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+      {{- with .Values.statefulset.podSecurityContext }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- with .Values.statefulset.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
@@ -42,10 +43,10 @@ spec:
       containers:
         - name: zigbee2mqtt
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- with .Values.statefulset.securityContext }}
           securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: TZ

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -49,6 +49,15 @@ statefulset:
   # -- Select specific kube node, this will allow enforcing zigbee2mqtt running
   # only on the node with the USB adapter connected
   nodeSelector: {}
+  # -- Configure Pods Security Context
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  # -- Configure Container Security Context
+  securityContext:
+    privileged: true
+    capabilities:
+      add: ["SYS_ADMIN"]
 zigbee2mqtt:
   homeassistant:
     enabled: true


### PR DESCRIPTION
Sorry for the PR spam =) 

This allows the user to configure `securityContext` for both the pod and the container.

I have it deployed with
```yaml
statefulset:
  podSecurityContext:
    fsGroup: 65534
    runAsGroup: 65534
    runAsUser: 65534
    fsGroupChangePolicy: "OnRootMismatch"
  securityContext:
    privileged: false
    capabilities:
      add: null
      drop:
      - all
    readOnlyRootFilesystem: true
    allowPrivilegeEscalation: false
```
and it works just fine, running unprivileged. Which is probably more desirable in most setups. Especially if the Zigbee adapter is accessed via network, rather than USB.