### PR TITLE
Use appversion as docker image tag unless user overrides it

### DIFF
--- a/charts/zigbee2mqtt/README.md
+++ b/charts/zigbee2mqtt/README.md
@@ -29,7 +29,7 @@ Kubernetes: `>=1.26.0-0`
 | image.imagePullSecrets | object | `{}` | Container additional secrets to pull image |
 | image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | image.repository | string | `"koenkk/zigbee2mqtt"` | Image repository for the `zigbee2mqtt` container. |
-| image.tag | string | `"1.37.1"` | Version for the `zigbee2mqtt` container. |
+| image.tag | string | `""` | Version for the `zigbee2mqtt` container. |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"},{"path":"/api","pathType":"ImplementationSpecific"}]}],"ingressClassName":"contour","labels":{},"pathType":"Prefix","tls":[{"hosts":["yourdomain.com"],"secretName":"some-tls-secret"}]}` | Ingress configuration. Zigbee2mqtt does use webssockets, which is not part of the Ingress standart settings. most of the popular ingresses supports them through annotations. Please check https://www.zigbee2mqtt.io/guide/installation/08_kubernetes.html for examples. |
 | ingress.enabled | bool | `false` | When enabled a new Ingress will be created |
 | ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"},{"path":"/api","pathType":"ImplementationSpecific"}]}]` | list of hosts that should be allowed for the zigbee2mqtt service |

--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
 {{- end }}
       containers:
         - name: zigbee2mqtt
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- with .Values.statefulset.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -7,7 +7,7 @@ image:
   # -- Image repository for the `zigbee2mqtt` container.
   repository: koenkk/zigbee2mqtt
   # -- Version for the `zigbee2mqtt` container.
-  tag: "1.37.1"
+  tag: ""
   # -- Container pull policy
   pullPolicy: IfNotPresent
   # -- Container additional secrets to pull image


### PR DESCRIPTION
This fixes the image version issues.

```
➜  zigbee2mqtt-chart git:(helm_versions) helm template charts/zigbee2mqtt | grep koenkk                             
          image: "koenkk/zigbee2mqtt:2.0.0"

```