### PR TITLE
make config file optionally writeable

### DIFF
--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -40,6 +40,32 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}
+      {{- if .Values.statefulset.writeableConfig }}
+      initContainers:
+        - name: yq
+          image: "{{ .Values.statefulset.configMigration.image.repository }}:{{ .Values.statefulset.configMigration.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "/bin/sh" ]
+          securityContext:
+            runAsUser: {{ coalesce .Values.statefulset.securityContext.runAsUser "0" }}
+            runAsGroup: {{ coalesce .Values.statefulset.securityContext.runAsGroup "0" }}
+          args:
+            - -xc
+            - |
+              if [ ! -f /app/data/configuration.yaml ]; then
+                echo "Copying config, since destination does not exist.."
+                cp -v /config/configuration.yaml /app/data/configuration.yaml
+              else
+                echo "Found existing config. Merging values.."
+                yq eval-all --inplace '. as $item ireduce ({}; . * $item )' /app/data/configuration.yaml /config/configuration.yaml
+              fi
+          volumeMounts:
+            - mountPath: /app/data/
+              name: data-volume
+            - mountPath: /config/configuration.yaml
+              name: config-volume
+              subPath: configuration.yaml
+      {{- end }}
       containers:
         - name: zigbee2mqtt
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -67,9 +93,11 @@ spec:
           {{- with .Values.statefulset.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+            {{- if not .Values.statefulset.writeableConfig }}
             - mountPath: /app/data/configuration.yaml
               name: config-volume
               subPath: configuration.yaml
+            {{- end }}
             {{- if .Values.statefulset.secrets.name }}
             - mountPath: /app/data/secret.yaml
               name: secrets-volume

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -20,6 +20,12 @@ service:
   # -- port in which the service will be listening
   port: 8080
 statefulset:
+  # -- if enabled, the config file made available to the application is writeable
+  writeableConfig: false
+  configMigration:
+    image:
+      repository: mikefarah/yq
+      tag: 4.45.1
   storage:
     enabled: false
     size: 1Gi


### PR DESCRIPTION
by

* introducing new bool flag `statefulset.writeableConfig`

which, if explictly enabled, will

* mount `configuration.yaml` from the `configMap` to `/config` instead of `/app/data`
* use an `initContainer` (configurable via `statefulset.configMigration.image`) to
  * copy `/config/configuration.yaml` to `/app/data/configuration.yaml`, if the latter does not exist
  * merge both config files, giving priority to the contents in `/config/configuration.yaml`

When enabled, the rendered diff from `helm template` is as follows
```diff
--- old.yaml	2025-01-17 20:08:40
+++ new.yaml	2025-01-17 20:08:46
@@ -119,6 +119,30 @@
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+        - name: yq
+          image: "mikefarah/yq:4.45.1"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/sh" ]
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          args:
+            - -xc
+            - |
+              if [ ! -f /app/data/configuration.yaml ]; then
+                echo "Copying config, since destination does not exist.."
+                cp -v /config/configuration.yaml /app/data/configuration.yaml
+              else
+                echo "Found existing config. Merging values.."
+                yq eval-all --inplace '. as $item ireduce ({}; . * $item )' /app/data/configuration.yaml /config/configuration.yaml
+              fi
+          volumeMounts:
+            - mountPath: /app/data/
+              name: data-volume
+            - mountPath: /config/configuration.yaml
+              name: config-volume
+              subPath: configuration.yaml
       containers:
         - name: zigbee2mqtt
           image: "koenkk/zigbee2mqtt:1.37.1"
@@ -144,9 +168,6 @@
             periodSeconds: 30
             timeoutSeconds: 10
           volumeMounts:
-            - mountPath: /app/data/configuration.yaml
-              name: config-volume
-              subPath: configuration.yaml
             - mountPath: /app/data/
               name: data-volume
           resources:
```

This fixes #4 and #27.
