### PR TITLE
Enable upgrades to z2m v2 (configuration migrations)

### DIFF
--- a/charts/zigbee2mqtt/README.md
+++ b/charts/zigbee2mqtt/README.md
@@ -38,6 +38,12 @@ Kubernetes: `>=1.26.0-0`
 | ingress.pathType | string | `"Prefix"` | Ingress implementation specific (potentially) for most use cases Prefix should be ok |
 | ingress.tls | list | `[{"hosts":["yourdomain.com"],"secretName":"some-tls-secret"}]` | configuration for tls service (ig any) |
 | nameOverride | string | `nil` | override the release name |
+| secretesMigratorContainer | object | `{"imagePullSecrets":{},"pullPolicy":"IfNotPresent","repository":"mikefarah/yq","securityContext":{"privileged":true,"runAsUser":0},"tag":"4.45.1"}` | details about the image |
+| secretesMigratorContainer.imagePullSecrets | object | `{}` | Container additional secrets to pull image |
+| secretesMigratorContainer.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
+| secretesMigratorContainer.repository | string | `"mikefarah/yq"` | Image repository for the `zigbee2mqtt` container. |
+| secretesMigratorContainer.securityContext | object | `{"privileged":true,"runAsUser":0}` | permissions to create files since z2m runs with root (by default) |
+| secretesMigratorContainer.tag | string | `"4.45.1"` | Version for the `zigbee2mqtt` container. |
 | service.annotations | object | `{}` | annotations for the service created |
 | service.port | int | `8080` | port in which the service will be listening |
 | service.type | string | `"LoadBalancer"` | type of Service to be created |
@@ -77,6 +83,7 @@ Kubernetes: `>=1.26.0-0`
 | zigbee2mqtt.blocklist | list | `[]` | Locking devices from the network ( ieeeAddr ) |
 | zigbee2mqtt.external_converters | list | `[]` |  |
 | zigbee2mqtt.frontend.auth_token | string | `nil` | Optional, enables authentication, disabled by default, cleartext (no hashing required) |
+| zigbee2mqtt.frontend.enabled | bool | `true` | If the front end should be enabled, true by default. Pod health checks are based on this, so disabling it will cause an error loop unless health checks are updated. |
 | zigbee2mqtt.frontend.host | string | `"0.0.0.0"` | Optional, empty by default to listen on both IPv4 and IPv6. Opens a unix socket when given a path instead of an address (e.g. '/run/zigbee2mqtt/zigbee2mqtt.sock') Don't set this if you use Docker or the Home Assistant add-on unless you're sure the chosen IP is available inside the container |
 | zigbee2mqtt.frontend.port | int | `8080` | Mandatory, default 8080 |
 | zigbee2mqtt.frontend.url | string | `nil` | Optional, url on which the frontend can be reached, currently only used for the Home Assistant device configuration page |

--- a/charts/zigbee2mqtt/templates/configmap.yaml
+++ b/charts/zigbee2mqtt/templates/configmap.yaml
@@ -11,6 +11,12 @@ metadata:
   {{- end }}
 data:
   configuration.yaml: |
+    # We keep version 3, even if the current version is 4. The reason is that previous installations
+    # will not have any version set in the config map. If we would set 4, it would skip the migration and z2m would
+    # have issues. Since we are moving to writable volumes, the init script will make version "soruce of truth" of existing
+    # persisted config if any.
+    # We will update this to 4 in future releases when we can assume users have upgraded.
+    version: 3
     # Define the files which contains the configs. As k8s config maps
     # Are read only by design, we need to extract dynamic config to external files
     devices: devices.yaml

--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -94,9 +94,13 @@ spec:
           args:
             - -c
             - |
-              if [ -f /app/data/configuration.yaml ]; then
+              if [ -f /app/data/configuration.yaml ]
+              then
                 echo "Backing up existing configuration file to /app/data/configuration-helm-backup.yaml"
                 cp /app/data/configuration.yaml /app/data/configuration-helm-backup.yaml
+              else
+                echo "configuration.yaml does not exists, creating one from config map /app/data/configmap-configuration.yaml"
+                cp /app/data/configmap-configuration.yaml /app/data/configuration.yaml
               fi
 
               yq --inplace '. *= load("/app/data/configmap-configuration.yaml") | del(.version) ' /app/data/configuration.yaml

--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -82,11 +82,11 @@ spec:
         - name: yq
           ## hardcoding here the image. It will be either available in z2m or it will be added to config.
           ## not creating entries config yet so users don't couple with it, causing migration issues.
-          image: "mikefarah/yq:4.45.1"
+          image: "{{ .Values.secretesMigratorContainer.repository }}:{{ .Values.secretesMigratorContainer.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [ "/bin/sh" ]
           workingDir: "/app/data"
-          {{- with .Values.statefulset.securityContext }}
+          {{- with .Values.secretesMigratorContainer.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -67,7 +67,7 @@ spec:
           {{- with .Values.statefulset.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-            - mountPath: /app/data/configuration.yaml
+            - mountPath: /app/data/configmap-configuration.yaml
               name: config-volume
               subPath: configuration.yaml
             {{- if .Values.statefulset.secrets.name }}
@@ -78,6 +78,35 @@ spec:
             - mountPath: /app/data/
               name: data-volume
           resources: {{- toYaml .Values.statefulset.resources | nindent 12 }}
+      initContainers:
+        - name: yq
+          ## hardcoding here the image. It will be either available in z2m or it will be added to config.
+          ## not creating entries config yet so users don't couple with it, causing migration issues.
+          image: "mikefarah/yq:4.45.1"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "/bin/sh" ]
+          {{- with .Values.statefulset.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ## this scripts copies all the data from the configmap to configuration.yaml (except the version)
+          ## and then copies the version from the configmap if it does not (already) exist in configuration.yaml
+          args:
+            - -c
+            - |
+              if [ -f /app/data/configuration.yaml ]; then
+                echo "Backing up existing configuration file to /app/data/configuration-helm-backup.yaml"
+                cp /app/data/configuration.yaml /app/data/configuration-helm-backup.yaml
+              fi
+
+              yq --inplace '. *= load("/app/data/configmap-configuration.yaml") | del(.version) ' /app/data/configuration.yaml
+              yq eval-all  '. as $item ireduce ({}; . * $item )' /app/data/configmap-configuration.yaml /app/data/configuration.yaml > /app/data/configuration.yaml
+          volumeMounts:
+            - mountPath: /app/data/
+              name: data-volume
+            - mountPath: /app/data/configmap-configuration.yaml
+              name: config-volume
+              subPath: configuration.yaml
       volumes:
       {{- with .Values.statefulset.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -85,6 +85,7 @@ spec:
           image: "mikefarah/yq:4.45.1"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [ "/bin/sh" ]
+          workingDir: "/app/data"
           {{- with .Values.statefulset.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -94,17 +95,17 @@ spec:
           args:
             - -c
             - |
-              if [ -f /app/data/configuration.yaml ]
+              if [ -f configuration.yaml ]
               then
                 echo "Backing up existing configuration file to /app/data/configuration-helm-backup.yaml"
-                cp /app/data/configuration.yaml /app/data/configuration-helm-backup.yaml
+                cp configuration.yaml configuration-helm-backup.yaml
               else
                 echo "configuration.yaml does not exists, creating one from config map /app/data/configmap-configuration.yaml"
-                cp /app/data/configmap-configuration.yaml /app/data/configuration.yaml
+                cp configmap-configuration.yaml configuration.yaml
               fi
 
-              yq --inplace '. *= load("/app/data/configmap-configuration.yaml") | del(.version) ' /app/data/configuration.yaml
-              yq eval-all  '. as $item ireduce ({}; . * $item )' /app/data/configmap-configuration.yaml /app/data/configuration.yaml > /app/data/configuration.yaml
+              yq --inplace '. *= load("configmap-configuration.yaml") | del(.version) ' configuration.yaml
+              yq eval-all  '. as $item ireduce ({}; . * $item )' configmap-configuration.yaml configuration.yaml > configuration.yaml
           volumeMounts:
             - mountPath: /app/data/
               name: data-volume

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -12,6 +12,24 @@ image:
   pullPolicy: IfNotPresent
   # -- Container additional secrets to pull image
   imagePullSecrets: {}
+
+# -- details about the image
+secretesMigratorContainer:
+  # -- Image repository for the `zigbee2mqtt` container.
+  repository: "mikefarah/yq"
+  # -- Version for the `zigbee2mqtt` container.
+  tag: "4.45.1"
+  # -- Container pull policy
+  pullPolicy: IfNotPresent
+  # -- Container additional secrets to pull image
+  imagePullSecrets: { }
+  # -- Security context for the container that migrates the configuration
+  # -- yq runs by default with user 1000 which does not have
+  # -- permissions to create files since z2m runs with root (by default)
+  securityContext:
+    runAsUser: 0
+    privileged: true
+
 service:
   # -- annotations for the service created
   annotations: {}
@@ -20,6 +38,7 @@ service:
   # -- port in which the service will be listening
   port: 8080
 statefulset:
+
   storage:
     enabled: false
     size: 1Gi
@@ -154,6 +173,9 @@ zigbee2mqtt:
     # -- Disable automatic update checks
     disable_automatic_update_check: false
   frontend:
+    # -- If the front end should be enabled, true by default. Pod health checks are based on this, so disabling
+    # it will cause an error loop unless health checks are updated.
+    enabled: true
     # -- Mandatory, default 8080
     port: 8080
     # -- Optional, empty by default to listen on both IPv4 and IPv6. Opens a unix socket when given a path instead of an address (e.g. '/run/zigbee2mqtt/zigbee2mqtt.sock')


### PR DESCRIPTION
This PRs stops using the config map created by helm as the final configuration file. fixes https://github.com/Koenkk/zigbee2mqtt-chart/issues/27

* Version 3 as default (to enable previous users) is added to the config map.
* An init container is created that merges config map with existing z2m settings (using the config map as source of truth).
* Configuration changes made through the UI are lost on reboots.
* Existing configuration is backed up before the changes are applied to the configuration file. 
* Adds new security settings for the init containter as by default runs with a non root user, since z2m runs with root (by default) it does not have write permissions.
* Enable by default UI so the healthchecks can be enabled.

This change should be transparent for existing or new users.
