### PR TITLE
Don't run yq with privileged

### DIFF
--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -28,7 +28,6 @@ secretesMigratorContainer:
   # -- permissions to create files since z2m runs with root (by default)
   securityContext:
     runAsUser: 0
-    privileged: true
 
 service:
   # -- annotations for the service created


### PR DESCRIPTION
Running containers as privileged is a security risk. Privileged containers should not be used unless absolutely necessary (e.g. to access usb devices). The yq init container is only used to modify a config file owned by root, so it should not run with privileged.

https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K01-insecure-workload-configurations

I have tested that the yq script works fine without privileged. If users are using a custom yq script that requires privileged, they can can specify their own securityContext in values.yaml.