### PR TITLE
Remove default value for tag

### DIFF
--- a/charts/zigbee2mqtt/README.md
+++ b/charts/zigbee2mqtt/README.md
@@ -29,7 +29,7 @@ Kubernetes: `>=1.26.0-0`
 | image.imagePullSecrets | object | `{}` | Container additional secrets to pull image |
 | image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | image.repository | string | `"koenkk/zigbee2mqtt"` | Image repository for the `zigbee2mqtt` container. |
-| image.tag | string | `"2.1.1"` | Version for the `zigbee2mqtt` container. |
+| image.tag | string | `nil` | Version for the `zigbee2mqtt` container. If left as null it will use the chart appVersion |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"},{"path":"/api","pathType":"ImplementationSpecific"}]}],"ingressClassName":"contour","labels":{},"pathType":"Prefix","tls":[{"hosts":["yourdomain.com"],"secretName":"some-tls-secret"}]}` | Ingress configuration. Zigbee2mqtt does use webssockets, which is not part of the Ingress standart settings. most of the popular ingresses supports them through annotations. Please check https://www.zigbee2mqtt.io/guide/installation/08_kubernetes.html for examples. |
 | ingress.enabled | bool | `false` | When enabled a new Ingress will be created |
 | ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"},{"path":"/api","pathType":"ImplementationSpecific"}]}]` | list of hosts that should be allowed for the zigbee2mqtt service |
@@ -38,11 +38,11 @@ Kubernetes: `>=1.26.0-0`
 | ingress.pathType | string | `"Prefix"` | Ingress implementation specific (potentially) for most use cases Prefix should be ok |
 | ingress.tls | list | `[{"hosts":["yourdomain.com"],"secretName":"some-tls-secret"}]` | configuration for tls service (ig any) |
 | nameOverride | string | `nil` | override the release name |
-| secretesMigratorContainer | object | `{"imagePullSecrets":{},"pullPolicy":"IfNotPresent","repository":"mikefarah/yq","securityContext":{"privileged":true,"runAsUser":0},"tag":"4.45.1"}` | details about the image |
+| secretesMigratorContainer | object | `{"imagePullSecrets":{},"pullPolicy":"IfNotPresent","repository":"mikefarah/yq","securityContext":{"runAsUser":0},"tag":"4.45.1"}` | details about the image |
 | secretesMigratorContainer.imagePullSecrets | object | `{}` | Container additional secrets to pull image |
 | secretesMigratorContainer.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | secretesMigratorContainer.repository | string | `"mikefarah/yq"` | Image repository for the `zigbee2mqtt` container. |
-| secretesMigratorContainer.securityContext | object | `{"privileged":true,"runAsUser":0}` | permissions to create files since z2m runs with root (by default) |
+| secretesMigratorContainer.securityContext | object | `{"runAsUser":0}` | permissions to create files since z2m runs with root (by default) |
 | secretesMigratorContainer.tag | string | `"4.45.1"` | Version for the `zigbee2mqtt` container. |
 | service.annotations | object | `{}` | annotations for the service created |
 | service.port | int | `8080` | port in which the service will be listening |

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -6,7 +6,7 @@ customLabels: {}
 image:
   # -- Image repository for the `zigbee2mqtt` container.
   repository: koenkk/zigbee2mqtt
-  # -- Version for the `zigbee2mqtt` container.
+  # -- Version for the `zigbee2mqtt` container. If left as null it will use the chart appVersion
   tag: null
   # -- Container pull policy
   pullPolicy: IfNotPresent
@@ -22,7 +22,7 @@ secretesMigratorContainer:
   # -- Container pull policy
   pullPolicy: IfNotPresent
   # -- Container additional secrets to pull image
-  imagePullSecrets: { }
+  imagePullSecrets: {}
   # -- Security context for the container that migrates the configuration
   # -- yq runs by default with user 1000 which does not have
   # -- permissions to create files since z2m runs with root (by default)
@@ -37,7 +37,6 @@ service:
   # -- port in which the service will be listening
   port: 8080
 statefulset:
-
   storage:
     enabled: false
     size: 1Gi
@@ -99,8 +98,8 @@ statefulset:
 zigbee2mqtt:
   homeassistant:
     enabled: true
-    discovery_topic: 'homeassistant'
-    status_topic: 'hass/status'
+    discovery_topic: "homeassistant"
+    status_topic: "hass/status"
     legacy_entity_attributes: true
     legacy_triggers: false
   # -- Optional: allow new devices to join.
@@ -200,7 +199,7 @@ zigbee2mqtt:
     log_output:
       - console
     log_level: info
-    timestamp_format: 'YYYY-MM-DD HH:mm:ss'
+    timestamp_format: "YYYY-MM-DD HH:mm:ss"
     # -- Optional: state caching, MQTT message payload will contain all attributes, not only changed ones.
     # -- Has to be true when integrating via Home Assistant (default: true)
     cache_state: true
@@ -210,7 +209,7 @@ zigbee2mqtt:
     cache_state_send_on_startup: true
     # -- Optional: Add a last_seen attribute to MQTT messages, contains date/time of last Zigbee message
     # possible values are: disable (default), ISO_8601, ISO_8601_local, epoch (default: disable)
-    last_seen: 'disable'
+    last_seen: "disable"
     # -- Optional: Add an elapsed attribute to MQTT messages, contains milliseconds since the previous msg (default: false)
     elapsed: false
     # -- Optional: Enables report feature, this feature is DEPRECATED since reporting is now setup by default

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -7,7 +7,7 @@ image:
   # -- Image repository for the `zigbee2mqtt` container.
   repository: koenkk/zigbee2mqtt
   # -- Version for the `zigbee2mqtt` container.
-  tag: "2.1.1"
+  tag: null
   # -- Container pull policy
   pullPolicy: IfNotPresent
   # -- Container additional secrets to pull image


### PR DESCRIPTION
This removes the default for the tag field meaning by default the chart App version will be used instead. This ensures the Helm chart version always corresponds to the version of the app being deployed.