### PR TITLE
Disable onboarding

### DIFF
--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -53,6 +53,8 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: Z2M_ONBOARD_NO_SERVER
+              value: "1"
             - name: TZ
               value: {{ .Values.zigbee2mqtt.timezone }}
           ports:


### PR DESCRIPTION
Since on K8S the `configuration.yaml` is not writeable (something which the onboarding features requires), the onboarding has to be disabled (https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/pull/740).

CC: @jlpedrosa @nerivec