### PR TITLE
Add annotations to data-volume volumeClaimTemplate

### DIFF
--- a/charts/zigbee2mqtt/Chart.yaml
+++ b/charts/zigbee2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.3.0"
 description: Bridges events and allows you to control your Zigbee devices via MQTT
 name: zigbee2mqtt
-version: "2.3.0"
+version: "2.3.1"
 kubeVersion: ">=1.26.0-0"
 keywords:
   - zigbee

--- a/charts/zigbee2mqtt/README.md
+++ b/charts/zigbee2mqtt/README.md
@@ -56,6 +56,7 @@ Kubernetes: `>=1.26.0-0`
 | statefulset.resources | object | `{"limits":{"cpu":"200m","memory":"600Mi"},"requests":{"cpu":"200m","memory":"600Mi"}}` | CPU/Memory configuration for the pods |
 | statefulset.secrets.name | string | `""` | the name for the kubernets secret to mount as secret.yaml. This can be referenced in the config by using advanced configurations https://www.zigbee2mqtt.io/guide/configuration/frontend.html#advanced-configuration |
 | statefulset.securityContext | object | `{"capabilities":{"add":["SYS_ADMIN"]},"privileged":true}` | Configure Container Security Context |
+| statefulset.storage.annotations | object | `{}` |  |
 | statefulset.storage.enabled | bool | `false` |  |
 | statefulset.storage.existingVolume | string | `""` |  |
 | statefulset.storage.matchExpressions | object | `{}` |  |

--- a/charts/zigbee2mqtt/README.md
+++ b/charts/zigbee2mqtt/README.md
@@ -1,6 +1,6 @@
 # zigbee2mqtt
 
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 Bridges events and allows you to control your Zigbee devices via MQTT
 
@@ -47,6 +47,7 @@ Kubernetes: `>=1.26.0-0`
 | service.annotations | object | `{}` | annotations for the service created |
 | service.port | int | `8080` | port in which the service will be listening |
 | service.type | string | `"LoadBalancer"` | type of Service to be created |
+| statefulset.affinity | object | `{}` | Node affinity for the pods |
 | statefulset.command | object | `{}` | Overrides the entrypoint of the container |
 | statefulset.dnsPolicy | string | `"ClusterFirst"` | pod dns policy |
 | statefulset.lifecycle | object | `{}` | Lifecycle configuration for the container |

--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -138,8 +138,10 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: data-volume
+    {{- if .Values.statefulset.storage.annotations }}
       annotations:
-        {{ toYaml .Values.statefulset.storage.annotations | indent 8 }}
+        {{- toYaml .Values.statefulset.storage.annotations | nindent 8 }}
+    {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       storageClassName: {{ .Values.statefulset.storage.storageClassName }}

--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -138,6 +138,8 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: data-volume
+      annotations:
+        {{ toYaml .Values.statefulset.storage.annotations | indent 8 }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       storageClassName: {{ .Values.statefulset.storage.storageClassName }}

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -47,6 +47,8 @@ statefulset:
     ## https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector
     matchLabels: {}
     matchExpressions: {}
+    ## -- annotations to add to the persistent volume claim
+    annotations: {}
   secrets:
     # -- the name for the kubernets secret to mount as secret.yaml. This can be referenced in the config
     # by using advanced configurations https://www.zigbee2mqtt.io/guide/configuration/frontend.html#advanced-configuration

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -70,6 +70,8 @@ statefulset:
   # -- Select specific kube node, this will allow enforcing zigbee2mqtt running
   # only on the node with the USB adapter connected
   nodeSelector: {}
+  # -- Node affinity for the pods
+  affinity: {}
   # -- Lifecycle configuration for the container
   lifecycle: {}
   # -- Configure Pods Security Context


### PR DESCRIPTION
Hey, thanks for providing a chart, it helps me a lot!
I was missing the ability to add annotations to the PVC created by the StatefulSet so i thought i can just contribute that. During that i noticed that a default value for the `affinity` was missing so i added that too

I'm not 100% sure about your release workflow. I bumped the patch version of the chart for now, or should that not diverge with the app version?