### PR TITLE
fix: render blocklist via toJson to Preserve Quoted Hex Strings

### DIFF
--- a/charts/zigbee2mqtt/templates/configmap.yaml
+++ b/charts/zigbee2mqtt/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
     ota:
       {{- .Values.zigbee2mqtt.ota | toYaml | nindent 6}}
     permit_join: {{ .Values.zigbee2mqtt.permit_join }}
-    blocklist: {{ .Values.zigbee2mqtt.blocklist }}
+    blocklist: {{ toJson .Values.zigbee2mqtt.blocklist }}
     {{- if .Values.zigbee2mqtt.availability }}
     availability:
       {{- .Values.zigbee2mqtt.availability | toYaml | nindent 6}}


### PR DESCRIPTION
**Issue:** When users supply a hex‑string blocklist (e.g. "0x540f57fffef59565"), the default Go‑YAML marshaler strips the quotes and emits it as a bare scalar or integer (blocklist: [0x540f57fffef59565]), which Zigbee2MQTT rejects because it expects string values.

**Cause:** The chart’s template uses {{ .Values.zigbee2mqtt.blocklist }}, so Helm’s internal marshaling loses the YAML quoting on plain‑style scalars.

**Impact:** Blocklists containing hex IDs silently become invalid at runtime, causing devices to be incorrectly blocked or the service to error out.

**Fix:** Switches the blocklist template to use toJson, which emits a JSON array literal (e.g. ["0x540f57fffef59565"]).
This ensures that hex IDs remain quoted in the final configuration.yaml, satisfying Zigbee2MQTT’s schema requirements without requiring end‑users to patch their values or maintain forks.

**Example:**
With-out `toJson`:
```yaml
blocklist: [0x540f57fffef59565] <- no quotes and fails
```
With `toJson`:
```yaml
blocklist: ["0x540f57fffef59565"]
```