### PR TITLE
Fix customLabels indentation

### DIFF
--- a/charts/zigbee2mqtt/templates/_helpers.tpl
+++ b/charts/zigbee2mqtt/templates/_helpers.tpl
@@ -32,6 +32,6 @@ app.kubernetes.io/name: "{{ template "zigbee2mqtt.name" . }}"
 app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- if .Values.customLabels }}
-{{ toYaml .Values.customLabels | indent 2 -}}
+{{ toYaml .Values.customLabels -}}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
customLabels are not aligned with the other labels

Eg
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: zigbee2mqtt
  namespace: zigbee2mqtt
  labels:
    app.kubernetes.io/instance: "zigbee2mqtt"
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/name: "zigbee2mqtt"
    app.kubernetes.io/version: "2.5.1"
    helm.sh/chart: "zigbee2mqtt-2.5.1"
      homelab.io/role.smarthome: "true"
```

Removing the ` | indent 2` should fix it.