### PR TITLE
Add Gateway API support

### DIFF
--- a/charts/zigbee2mqtt/README.md
+++ b/charts/zigbee2mqtt/README.md
@@ -29,6 +29,12 @@ Kubernetes: `>=1.26.0-0`
 | customLabels | object | `{}` |  |
 | extraResources | list | `[]` | Extra Resources. Define some extra resources to be created, such as ExternalResource or Secrets, etc. |
 | fullnameOverride | string | `nil` | override the name of the objects generated |
+| httproute.annotations | object | `{}` | Annotations for the HTTPRoute resource in the form of key-value pairs. |
+| httproute.enabled | bool | `false` | Setting that allows Zigbee2mqtt to generate HTTPRoute records for the Zigbee2mqtt UI service using Gateway API. |
+| httproute.hostnames | list | `[]` | List of hostnames for the HTTPRoute. Multiple hostnames are supported. |
+| httproute.parentRefs | list | `[]` | Gateway references for HTTPRoute. Specify which Gateway(s) should handle this route. |
+| httproute.path | string | `"/"` | Default path for HTTPRoute. You can access the Zigbee2mqtt UI by following the full path. |
+| httproute.pathType | string | `"PathPrefix"` | Path match type for HTTPRoute. (Options: "Exact", "PathPrefix") |
 | image.imagePullSecrets | object | `{}` | Container additional secrets to pull image |
 | image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | image.repository | string | `"koenkk/zigbee2mqtt"` | Image repository for the `zigbee2mqtt` container. |

--- a/charts/zigbee2mqtt/templates/httproute.yaml
+++ b/charts/zigbee2mqtt/templates/httproute.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.httproute.enabled -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $fullName := include "zigbee2mqtt.fullname" . }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "zigbee2mqtt.labels" . | nindent 4 }}
+    {{- with .Values.httproute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ tpl $value $ | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.parentRefs }}
+  parentRefs:
+    {{- range . }}
+    - group: {{ .group | default "gateway.networking.k8s.io" }}
+      kind: {{ .kind | default "Gateway" }}
+      name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+  - matches:
+    - path:
+        type: {{ .Values.httproute.pathType | default "PathPrefix" }}
+        value: {{ .Values.httproute.path | default "/" }}
+    backendRefs:
+    - name: {{ $fullName }}
+      port: {{ $servicePort }}
+{{- end }}

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -283,6 +283,31 @@ ingress:
       hosts:
         - yourdomain.com
 
+httproute:
+  # -- Setting that allows Zigbee2mqtt to generate HTTPRoute records for the Zigbee2mqtt UI service using Gateway API.
+  enabled: false
+  # -- Gateway references for HTTPRoute. Specify which Gateway(s) should handle this route.
+  parentRefs: []
+  ## Example:
+  # - name: gateway-name
+  #   namespace: gateway-namespace
+  #   # Optional fields with defaults:
+  #   # group: gateway.networking.k8s.io   # default
+  #   # kind: Gateway                      # default
+  #   # sectionName: https                 # optional, targets a specific listener
+  # -- List of hostnames for the HTTPRoute. Multiple hostnames are supported.
+  hostnames: []
+  ## Example:
+  # - zigbee2mqtt.example.com
+  # - zigbee2mqtt.example.org
+  # -- Default path for HTTPRoute. You can access the Zigbee2mqtt UI by following the full path.
+  path: /
+  # -- Path match type for HTTPRoute. (Options: "Exact", "PathPrefix")
+  pathType: PathPrefix
+  # -- Annotations for the HTTPRoute resource in the form of key-value pairs.
+  annotations: {}
+  ## Example:
+
 # -- Extra Resources. Define some extra resources to be created, such as ExternalResource or Secrets, etc.
 extraResources: []
   # - apiVersion: v1


### PR DESCRIPTION
# Description

This PR introduces support for Kubernetes [Gateway API](https://kubernetes.io/docs/concepts/services-networking/gateway/) by adding an HTTPRoute resource, providing an alternative to traditional Ingress for routing HTTP traffic to the Zigbee2MQTT UI.

This enhancement allows users to adopt Gateway API routing while maintaining backward compatibility with existing Ingress setups.

## Usage

Example of values required to enable the Gateway API HTTPRoute:
```yaml
httproute:
  enabled: true
  parentRefs:
    - name: my-gateway
      namespace: gateway-system
  hostnames:
    - zigbee2mqtt.example.com
```