### PR TITLE
feat(zigbee2mqtt): Add kubernetes network policies

### DIFF
--- a/charts/zigbee2mqtt/Chart.yaml
+++ b/charts/zigbee2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.11.0"
 description: Bridges events and allows you to control your Zigbee devices via MQTT
 name: zigbee2mqtt
-version: "2.11.0"
+version: "2.11.1"
 kubeVersion: ">=1.26.0-0"
 keywords:
   - zigbee

--- a/charts/zigbee2mqtt/README.md
+++ b/charts/zigbee2mqtt/README.md
@@ -48,6 +48,12 @@ Kubernetes: `>=1.26.0-0`
 | ingress.pathType | string | `"Prefix"` | Ingress implementation specific (potentially) for most use cases Prefix should be ok |
 | ingress.tls | list | `[{"hosts":["yourdomain.com"],"secretName":"some-tls-secret"}]` | configuration for tls service (ig any) |
 | nameOverride | string | `nil` | override the release name |
+| networkPolicy.cilium.egress | list | `[]` | Cilium network policy egress https://docs.cilium.io/en/stable/security/policy/ |
+| networkPolicy.cilium.ingress | list | `[]` | Cilium network policy ingress https://docs.cilium.io/en/stable/security/policy/ |
+| networkPolicy.egress  | list | `[]` | Kubernetes egress spec https://kubernetes.io/docs/concepts/services-networking/network-policies/ |
+| networkPolicy.enabled | bool | `false` | Enable network policy management |
+| networkPolicy.flavor | string | `kubernetes` | Network policy mode in kubernetes, cilium |
+| networkPolicy.ingress  | list | `[]` |  | Kubernetes ingress spec https://kubernetes.io/docs/concepts/services-networking/network-policies/ |
 | secretesMigratorContainer | object | `{"imagePullSecrets":{},"pullPolicy":"IfNotPresent","repository":"mikefarah/yq","securityContext":{"runAsUser":0},"tag":"4.45.1"}` | details about the image |
 | secretesMigratorContainer.imagePullSecrets | object | `{}` | Container additional secrets to pull image |
 | secretesMigratorContainer.pullPolicy | string | `"IfNotPresent"` | Container pull policy |

--- a/charts/zigbee2mqtt/templates/ciliumnetworkpolicy.yaml
+++ b/charts/zigbee2mqtt/templates/ciliumnetworkpolicy.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.networkPolicy.enabled (eq .Values.networkPolicy.flavor "cilium") }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "zigbee2mqtt.fullname" . }}
+  labels:
+    {{- include "zigbee2mqtt.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s:app: '{{ include "zigbee2mqtt.fullname" . }}'
+  {{- if and .Values.networkPolicy.cilium .Values.networkPolicy.cilium.egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.cilium.egress | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.networkPolicy.cilium .Values.networkPolicy.cilium.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.cilium.ingress | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/zigbee2mqtt/templates/networkpolicy.yaml
+++ b/charts/zigbee2mqtt/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.networkPolicy.enabled (eq .Values.networkPolicy.flavor "kubernetes") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "zigbee2mqtt.labels" . | nindent 4 }}
+  name: {{ include "zigbee2mqtt.fullname" . }}
+spec:
+  {{- if .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+  {{- end }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  {{- end }}
+  policyTypes:
+  {{- if .Values.networkPolicy.egress }}
+    - Egress
+  {{- end }}
+  {{- if .Values.networkPolicy.ingress }}
+    - Ingress
+  {{- end }}
+  podSelector:
+    matchLabels:
+      app: {{ include "zigbee2mqtt.fullname" . }}
+{{- end }}

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -310,6 +310,45 @@ httproute:
   annotations: {}
   ## Example:
 
+networkPolicy:
+  # -- Setting network policies using differents flavors
+  enabled: false
+  # -- In cilium flavor mode, use the cilium network policy
+  cilium:
+    egress: []
+    # Exemple : Allow OTA updates
+    # - toFQDNs:
+    #   - matchName: raw.githubusercontent.com
+    #   toPorts:
+    #   - ports:
+    #     - port: "443"
+    #       protocol: TCP
+    # - toEndpoints:
+    #   - matchLabels:
+    #       k8s:io.kubernetes.pod.namespace: kube-system
+    #       k8s:k8s-app: kube-dns
+    #   toPorts:
+    #   - ports:
+    #     - port: "53"
+    #       protocol: UDP
+    #     - port: "53"
+    #       protocol: TCP
+    #     rules:
+    #       dns:
+    #       - matchName: raw.githubusercontent.com
+    # cluster ingress
+    ingress:
+    - toPorts:
+      - ports:
+        - port: web
+  # -- choose flavor in 'kubernetes', 'cilium'
+  flavor: kubernetes
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: web
+  egress: []
+
 # -- Extra Resources. Define some extra resources to be created, such as ExternalResource or Secrets, etc.
 extraResources: []
   # - apiVersion: v1


### PR DESCRIPTION
Proposal for a basic network policy handle, this allow security practices in home made cluster with restrictive permissions.
The aim it to avoid the administrator to set the "selector labels" that are managed by the chart itself