### PR TITLE
Add configmap.devices support for devices.yaml init copy to PVC

### DIFF
--- a/charts/zigbee2mqtt/README.md
+++ b/charts/zigbee2mqtt/README.md
@@ -25,6 +25,7 @@ Kubernetes: `>=1.26.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | configmap.annotations | object | `{}` | annotations for the configmap created |
+| configmap.devices | string | `nil` | Optional: devices.yaml content (managed in Git, copied to PVC on first start only) |
 | configmap.enabled | bool | `true` | Enable or disable the ConfigMap creation |
 | customLabels | object | `{}` |  |
 | extraResources | list | `[]` | Extra Resources. Define some extra resources to be created, such as ExternalResource or Secrets, etc. |

--- a/charts/zigbee2mqtt/templates/configmap.yaml
+++ b/charts/zigbee2mqtt/templates/configmap.yaml
@@ -51,4 +51,8 @@ data:
     passlist:
       {{- .Values.zigbee2mqtt.passlist | toYaml | nindent 6}}
     {{- end }}
+  {{- if .Values.configmap.devices }}
+  devices.yaml: |
+    {{- .Values.configmap.devices | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/zigbee2mqtt/templates/statefulset.yaml
+++ b/charts/zigbee2mqtt/templates/statefulset.yaml
@@ -125,12 +125,22 @@ spec:
 
               yq --inplace '. *= load("configmap-configuration.yaml") | del(.version) ' configuration.yaml
               yq eval-all  '. as $item ireduce ({}; . * $item )' configmap-configuration.yaml configuration.yaml > configuration.yaml
+
+              if [ -f configmap-devices.yaml ] && [ ! -f devices.yaml ]; then
+                echo "devices.yaml does not exist, copying from config map"
+                cp configmap-devices.yaml devices.yaml
+              fi
           volumeMounts:
             - mountPath: /app/data/
               name: data-volume
             - mountPath: /app/data/configmap-configuration.yaml
               name: config-volume
               subPath: configuration.yaml
+            {{- if .Values.configmap.devices }}
+            - mountPath: /app/data/configmap-devices.yaml
+              name: config-volume
+              subPath: devices.yaml
+            {{- end }}
       {{- end }}
       volumes:
       {{- with .Values.statefulset.volumes }}

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -42,6 +42,8 @@ configmap:
   enabled: true
   # -- annotations for the configmap created
   annotations: {}
+  # -- Optional: devices.yaml content (managed in Git, copied to PVC on first start only)
+  devices: null
 statefulset:
   # -- annotations for the statefulset created
   annotations: {}


### PR DESCRIPTION
- Add configmap.devices value to chart values.yaml
- Add devices.yaml key to ConfigMap template (conditional on configmap.devices)
- Extend init container to copy devices.yaml from ConfigMap to PVC on first start only
- Mount devices ConfigMap in init container (conditional on configmap.devices)